### PR TITLE
fix(innerText): `text` should be replaced by `innerText`

### DIFF
--- a/lib/domain/atom_feed.dart
+++ b/lib/domain/atom_feed.dart
@@ -47,10 +47,10 @@ class AtomFeed {
     }
 
     return AtomFeed(
-      id: feedElement.findElements('id').firstOrNull?.value,
-      title: feedElement.findElements('title').firstOrNull?.value,
-      updated:
-          parseDateTime(feedElement.findElements('updated').firstOrNull?.value),
+      id: feedElement.findElements('id').firstOrNull?.innerText,
+      title: feedElement.findElements('title').firstOrNull?.innerText,
+      updated: parseDateTime(
+          feedElement.findElements('updated').firstOrNull?.innerText),
       items: feedElement
           .findElements('entry')
           .map((e) => AtomItem.parse(e))
@@ -75,10 +75,10 @@ class AtomFeed {
           .findElements('generator')
           .map((e) => AtomGenerator.parse(e))
           .firstOrNull,
-      icon: feedElement.findElements('icon').firstOrNull?.value,
-      logo: feedElement.findElements('logo').firstOrNull?.value,
-      rights: feedElement.findElements('rights').firstOrNull?.value,
-      subtitle: feedElement.findElements('subtitle').firstOrNull?.value,
+      icon: feedElement.findElements('icon').firstOrNull?.innerText,
+      logo: feedElement.findElements('logo').firstOrNull?.innerText,
+      rights: feedElement.findElements('rights').firstOrNull?.innerText,
+      subtitle: feedElement.findElements('subtitle').firstOrNull?.innerText,
     );
   }
 }

--- a/lib/domain/atom_generator.dart
+++ b/lib/domain/atom_generator.dart
@@ -10,7 +10,7 @@ class AtomGenerator {
   factory AtomGenerator.parse(XmlElement element) {
     var uri = element.getAttribute('uri');
     var version = element.getAttribute('version');
-    var value = element.value;
+    var value = element.innerText;
     return AtomGenerator(uri, version, value);
   }
 }

--- a/lib/domain/atom_item.dart
+++ b/lib/domain/atom_item.dart
@@ -41,10 +41,10 @@ class AtomItem {
 
   factory AtomItem.parse(XmlElement element) {
     return AtomItem(
-      id: element.findElements('id').firstOrNull?.value,
-      title: element.findElements('title').firstOrNull?.value,
+      id: element.findElements('id').firstOrNull?.innerText,
+      title: element.findElements('title').firstOrNull?.innerText,
       updated:
-          parseDateTime(element.findElements('updated').firstOrNull?.value),
+          parseDateTime(element.findElements('updated').firstOrNull?.innerText),
       authors: element
           .findElements('author')
           .map((e) => AtomPerson.parse(e))
@@ -63,10 +63,10 @@ class AtomItem {
           .findElements('source')
           .map((e) => AtomSource.parse(e))
           .firstOrNull,
-      published: element.findElements('published').firstOrNull?.value,
-      content: element.findElements('content').firstOrNull?.value,
-      summary: element.findElements('summary').firstOrNull?.value,
-      rights: element.findElements('rights').firstOrNull?.value,
+      published: element.findElements('published').firstOrNull?.innerText,
+      content: element.findElements('content').firstOrNull?.innerText,
+      summary: element.findElements('summary').firstOrNull?.innerText,
+      rights: element.findElements('rights').firstOrNull?.innerText,
       media: Media.parse(element),
     );
   }

--- a/lib/domain/atom_person.dart
+++ b/lib/domain/atom_person.dart
@@ -10,9 +10,9 @@ class AtomPerson {
 
   factory AtomPerson.parse(XmlElement element) {
     return AtomPerson(
-      name: element.findElements('name').firstOrNull?.value,
-      uri: element.findElements('uri').firstOrNull?.value,
-      email: element.findElements('email').firstOrNull?.value,
+      name: element.findElements('name').firstOrNull?.innerText,
+      uri: element.findElements('uri').firstOrNull?.innerText,
+      email: element.findElements('email').firstOrNull?.innerText,
     );
   }
 }

--- a/lib/domain/atom_source.dart
+++ b/lib/domain/atom_source.dart
@@ -14,9 +14,9 @@ class AtomSource {
 
   factory AtomSource.parse(XmlElement element) {
     return AtomSource(
-      id: element.findElements('id').firstOrNull?.value,
-      title: element.findElements('title').firstOrNull?.value,
-      updated: element.findElements('updated').firstOrNull?.value,
+      id: element.findElements('id').firstOrNull?.innerText,
+      title: element.findElements('title').firstOrNull?.innerText,
+      updated: element.findElements('updated').firstOrNull?.innerText,
     );
   }
 }

--- a/lib/domain/dublin_core/dublin_core.dart
+++ b/lib/domain/dublin_core/dublin_core.dart
@@ -43,25 +43,28 @@ class DublinCore {
 
   factory DublinCore.parse(XmlElement element) {
     return DublinCore(
-      title: element.findElements('dc:title').firstOrNull?.value,
-      description: element.findElements('dc:description').firstOrNull?.value,
-      creator: element.findElements('dc:creator').firstOrNull?.value,
-      subject: element.findElements('dc:subject').firstOrNull?.value,
-      publisher: element.findElements('dc:publisher').firstOrNull?.value,
-      contributor: element.findElements('dc:contributor').firstOrNull?.value,
-      date: parseDateTime(element.findElements('dc:date').firstOrNull?.value),
-      created:
-          parseDateTime(element.findElements('dc:created').firstOrNull?.value),
-      modified:
-          parseDateTime(element.findElements('dc:modified').firstOrNull?.value),
-      type: element.findElements('dc:type').firstOrNull?.value,
-      format: element.findElements('dc:format').firstOrNull?.value,
-      identifier: element.findElements('dc:identifier').firstOrNull?.value,
-      source: element.findElements('dc:source').firstOrNull?.value,
-      language: element.findElements('dc:language').firstOrNull?.value,
-      relation: element.findElements('dc:relation').firstOrNull?.value,
-      coverage: element.findElements('dc:coverage').firstOrNull?.value,
-      rights: element.findElements('dc:rights').firstOrNull?.value,
+      title: element.findElements('dc:title').firstOrNull?.innerText,
+      description:
+          element.findElements('dc:description').firstOrNull?.innerText,
+      creator: element.findElements('dc:creator').firstOrNull?.innerText,
+      subject: element.findElements('dc:subject').firstOrNull?.innerText,
+      publisher: element.findElements('dc:publisher').firstOrNull?.innerText,
+      contributor:
+          element.findElements('dc:contributor').firstOrNull?.innerText,
+      date:
+          parseDateTime(element.findElements('dc:date').firstOrNull?.innerText),
+      created: parseDateTime(
+          element.findElements('dc:created').firstOrNull?.innerText),
+      modified: parseDateTime(
+          element.findElements('dc:modified').firstOrNull?.innerText),
+      type: element.findElements('dc:type').firstOrNull?.innerText,
+      format: element.findElements('dc:format').firstOrNull?.innerText,
+      identifier: element.findElements('dc:identifier').firstOrNull?.innerText,
+      source: element.findElements('dc:source').firstOrNull?.innerText,
+      language: element.findElements('dc:language').firstOrNull?.innerText,
+      relation: element.findElements('dc:relation').firstOrNull?.innerText,
+      coverage: element.findElements('dc:coverage').firstOrNull?.innerText,
+      rights: element.findElements('dc:rights').firstOrNull?.innerText,
     );
   }
 }

--- a/lib/domain/itunes/itunes.dart
+++ b/lib/domain/itunes/itunes.dart
@@ -48,17 +48,17 @@ class Itunes {
 
   factory Itunes.parse(XmlElement element) {
     final episodeStr =
-        element.findElements('itunes:episode').firstOrNull?.value ?? '';
+        element.findElements('itunes:episode').firstOrNull?.innerText ?? '';
     final seasonStr =
-        element.findElements('itunes:season').firstOrNull?.value ?? '';
+        element.findElements('itunes:season').firstOrNull?.innerText ?? '';
     final durationStr =
-        element.findElements('itunes:duration').firstOrNull?.value ?? '';
+        element.findElements('itunes:duration').firstOrNull?.innerText ?? '';
     return Itunes(
-      author: element.findElements('itunes:author').firstOrNull?.value,
-      summary: element.findElements('itunes:summary').firstOrNull?.value,
+      author: element.findElements('itunes:author').firstOrNull?.innerText,
+      summary: element.findElements('itunes:summary').firstOrNull?.innerText,
       explicit: parseBoolLiteral(element, 'itunes:explicit'),
-      title: element.findElements('itunes:title').firstOrNull?.value,
-      subtitle: element.findElements('itunes:subtitle').firstOrNull?.value,
+      title: element.findElements('itunes:title').firstOrNull?.innerText,
+      subtitle: element.findElements('itunes:subtitle').firstOrNull?.innerText,
       owner: element
           .findElements('itunes:owner')
           .map((e) => ItunesOwner.parse(e))
@@ -66,8 +66,8 @@ class Itunes {
       keywords: element
               .findElements('itunes:keywords')
               .firstOrNull
-              ?.value
-              ?.split(',')
+              ?.innerText
+              .split(',')
               .map((keyword) => keyword.trim())
               .toList() ??
           [],
@@ -84,7 +84,7 @@ class Itunes {
           .map((e) => newItunesType(e))
           .firstOrNull,
       newFeedUrl:
-          element.findElements('itunes:new-feed-url').firstOrNull?.value,
+          element.findElements('itunes:new-feed-url').firstOrNull?.innerText,
       block: parseBoolLiteral(element, 'itunes:block'),
       complete: parseBoolLiteral(element, 'itunes:complete'),
       episode: episodeStr.isNotEmpty ? int.tryParse(episodeStr) : null,

--- a/lib/domain/itunes/itunes_episode_type.dart
+++ b/lib/domain/itunes/itunes_episode_type.dart
@@ -3,7 +3,7 @@ import 'package:xml/xml.dart';
 enum ItunesEpisodeType { full, trailer, bonus, unknown }
 
 ItunesEpisodeType newItunesEpisodeType(XmlElement element) {
-  switch (element.value) {
+  switch (element.innerText) {
     case 'full':
       return ItunesEpisodeType.full;
     case 'trailer':

--- a/lib/domain/itunes/itunes_owner.dart
+++ b/lib/domain/itunes/itunes_owner.dart
@@ -9,8 +9,8 @@ class ItunesOwner {
 
   factory ItunesOwner.parse(XmlElement element) {
     return ItunesOwner(
-      name: element.findElements('itunes:name').firstOrNull?.value?.trim(),
-      email: element.findElements('itunes:email').firstOrNull?.value?.trim(),
+      name: element.findElements('itunes:name').firstOrNull?.innerText.trim(),
+      email: element.findElements('itunes:email').firstOrNull?.innerText.trim(),
     );
   }
 }

--- a/lib/domain/itunes/itunes_type.dart
+++ b/lib/domain/itunes/itunes_type.dart
@@ -3,7 +3,7 @@ import 'package:xml/xml.dart';
 enum ItunesType { episodic, serial, unknown }
 
 ItunesType newItunesType(XmlElement element) {
-  switch (element.value) {
+  switch (element.innerText) {
     case 'episodic':
       return ItunesType.episodic;
     case 'serial':

--- a/lib/domain/media/category.dart
+++ b/lib/domain/media/category.dart
@@ -15,7 +15,7 @@ class Category {
     return Category(
       scheme: element.getAttribute('scheme'),
       label: element.getAttribute('label'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/copyright.dart
+++ b/lib/domain/media/copyright.dart
@@ -12,7 +12,7 @@ class Copyright {
   factory Copyright.parse(XmlElement element) {
     return Copyright(
       url: element.getAttribute('url'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/credit.dart
+++ b/lib/domain/media/credit.dart
@@ -15,7 +15,7 @@ class Credit {
     return Credit(
       role: element.getAttribute('role'),
       scheme: element.getAttribute('scheme'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/description.dart
+++ b/lib/domain/media/description.dart
@@ -12,7 +12,7 @@ class Description {
   factory Description.parse(XmlElement element) {
     return Description(
       type: element.getAttribute('type'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/hash.dart
+++ b/lib/domain/media/hash.dart
@@ -12,7 +12,7 @@ class Hash {
   factory Hash.parse(XmlElement element) {
     return Hash(
       algo: element.getAttribute('algo'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/license.dart
+++ b/lib/domain/media/license.dart
@@ -15,7 +15,7 @@ class License {
     return License(
       type: element.getAttribute('type'),
       href: element.getAttribute('href'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/media.dart
+++ b/lib/domain/media/media.dart
@@ -107,7 +107,7 @@ class Media {
           .findElements('media:description')
           .map((e) => Description.parse(e))
           .firstOrNull,
-      keywords: element.findElements('media:keywords').firstOrNull?.value,
+      keywords: element.findElements('media:keywords').firstOrNull?.innerText,
       thumbnails: element
           .findElements('media:thumbnail')
           .map((e) => Thumbnail.parse(e))

--- a/lib/domain/media/param.dart
+++ b/lib/domain/media/param.dart
@@ -12,7 +12,7 @@ class Param {
   factory Param.parse(XmlElement element) {
     return Param(
       name: element.getAttribute('name'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/peer_link.dart
+++ b/lib/domain/media/peer_link.dart
@@ -15,7 +15,7 @@ class PeerLink {
     return PeerLink(
       type: element.getAttribute('type'),
       href: element.getAttribute('href'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/player.dart
+++ b/lib/domain/media/player.dart
@@ -18,7 +18,7 @@ class Player {
       url: element.getAttribute('url'),
       width: int.tryParse(element.getAttribute('width') ?? '0'),
       height: int.tryParse(element.getAttribute('height') ?? '0'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/rating.dart
+++ b/lib/domain/media/rating.dart
@@ -12,7 +12,7 @@ class Rating {
   factory Rating.parse(XmlElement element) {
     return Rating(
       scheme: element.getAttribute('scheme'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/restriction.dart
+++ b/lib/domain/media/restriction.dart
@@ -15,7 +15,7 @@ class Restriction {
     return Restriction(
       relationship: element.getAttribute('relationship'),
       type: element.getAttribute('type'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/scene.dart
+++ b/lib/domain/media/scene.dart
@@ -16,10 +16,11 @@ class Scene {
 
   factory Scene.parse(XmlElement element) {
     return Scene(
-      title: element.findElements('sceneTitle').firstOrNull?.value,
-      description: element.findElements('sceneDescription').firstOrNull?.value,
-      startTime: element.findElements('sceneStartTime').firstOrNull?.value,
-      endTime: element.findElements('sceneEndTime').firstOrNull?.value,
+      title: element.findElements('sceneTitle').firstOrNull?.innerText,
+      description:
+          element.findElements('sceneDescription').firstOrNull?.innerText,
+      startTime: element.findElements('sceneStartTime').firstOrNull?.innerText,
+      endTime: element.findElements('sceneEndTime').firstOrNull?.innerText,
     );
   }
 }

--- a/lib/domain/media/tags.dart
+++ b/lib/domain/media/tags.dart
@@ -11,7 +11,7 @@ class Tags {
 
   factory Tags.parse(XmlElement element) {
     return Tags(
-      tags: element.value,
+      tags: element.innerText,
       weight: int.tryParse(element.getAttribute('weight') ?? '1'),
     );
   }

--- a/lib/domain/media/text.dart
+++ b/lib/domain/media/text.dart
@@ -21,7 +21,7 @@ class Text {
       lang: element.getAttribute('lang'),
       start: element.getAttribute('start'),
       end: element.getAttribute('end'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/media/title.dart
+++ b/lib/domain/media/title.dart
@@ -12,7 +12,7 @@ class Title {
   factory Title.parse(XmlElement element) {
     return Title(
       type: element.getAttribute('type'),
-      value: element.value,
+      value: element.innerText,
     );
   }
 }

--- a/lib/domain/rss_feed.dart
+++ b/lib/domain/rss_feed.dart
@@ -72,11 +72,11 @@ class RssFeed {
       throw ArgumentError('channel not found');
     }
     return RssFeed(
-      title: channelElement.findElements('title').firstOrNull?.value,
-      author: channelElement.findElements('author').firstOrNull?.value,
+      title: channelElement.findElements('title').firstOrNull?.innerText,
+      author: channelElement.findElements('author').firstOrNull?.innerText,
       description:
-          channelElement.findElements('description').firstOrNull?.value,
-      link: channelElement.findElements('link').firstOrNull?.value,
+          channelElement.findElements('description').firstOrNull?.innerText,
+      link: channelElement.findElements('link').firstOrNull?.innerText,
       items: (rdf ?? channelElement)
           .findElements('item')
           .map((e) => RssItem.parse(e))
@@ -104,21 +104,24 @@ class RssFeed {
               .findElements('skipHours')
               .firstOrNull
               ?.findAllElements('hour')
-              .map((e) => int.tryParse(e.value ?? '') ?? 0)
+              .map((e) => int.tryParse(e.innerText) ?? 0)
               .toList() ??
           [],
       lastBuildDate:
-          channelElement.findElements('lastBuildDate').firstOrNull?.value,
-      language: channelElement.findElements('language').firstOrNull?.value,
-      generator: channelElement.findElements('generator').firstOrNull?.value,
-      copyright: channelElement.findElements('copyright').firstOrNull?.value,
-      docs: channelElement.findElements('docs').firstOrNull?.value,
+          channelElement.findElements('lastBuildDate').firstOrNull?.innerText,
+      language: channelElement.findElements('language').firstOrNull?.innerText,
+      generator:
+          channelElement.findElements('generator').firstOrNull?.innerText,
+      copyright:
+          channelElement.findElements('copyright').firstOrNull?.innerText,
+      docs: channelElement.findElements('docs').firstOrNull?.innerText,
       managingEditor:
-          channelElement.findElements('managingEditor').firstOrNull?.value,
-      rating: channelElement.findElements('rating').firstOrNull?.value,
-      webMaster: channelElement.findElements('webMaster').firstOrNull?.value,
+          channelElement.findElements('managingEditor').firstOrNull?.innerText,
+      rating: channelElement.findElements('rating').firstOrNull?.innerText,
+      webMaster:
+          channelElement.findElements('webMaster').firstOrNull?.innerText,
       ttl: int.tryParse(
-          channelElement.findElements('ttl').firstOrNull?.value ?? '0'),
+          channelElement.findElements('ttl').firstOrNull?.innerText ?? '0'),
       dc: DublinCore.parse(channelElement),
       itunes: Itunes.parse(channelElement),
       syndication: Syndication.parse(channelElement),

--- a/lib/domain/rss_image.dart
+++ b/lib/domain/rss_image.dart
@@ -10,9 +10,9 @@ class RssImage {
 
   factory RssImage.parse(XmlElement element) {
     return RssImage(
-      title: element.findElements('title').firstOrNull?.value,
-      url: element.findElements('url').firstOrNull?.value,
-      link: element.findElements('link').firstOrNull?.value,
+      title: element.findElements('title').firstOrNull?.innerText,
+      url: element.findElements('url').firstOrNull?.innerText,
+      link: element.findElements('link').firstOrNull?.innerText,
     );
   }
 }

--- a/lib/domain/rss_item.dart
+++ b/lib/domain/rss_item.dart
@@ -45,18 +45,18 @@ class RssItem {
 
   factory RssItem.parse(XmlElement element) {
     return RssItem(
-      title: element.findElements('title').firstOrNull?.value,
-      description: element.findElements('description').firstOrNull?.value,
-      link: element.findElements('link').firstOrNull?.value,
+      title: element.findElements('title').firstOrNull?.innerText,
+      description: element.findElements('description').firstOrNull?.innerText,
+      link: element.findElements('link').firstOrNull?.innerText,
       categories: element
           .findElements('category')
           .map((e) => RssCategory.parse(e))
           .toList(),
-      guid: element.findElements('guid').firstOrNull?.value,
+      guid: element.findElements('guid').firstOrNull?.innerText,
       pubDate:
-          parseDateTime(element.findElements('pubDate').firstOrNull?.value),
-      author: element.findElements('author').firstOrNull?.value,
-      comments: element.findElements('comments').firstOrNull?.value,
+          parseDateTime(element.findElements('pubDate').firstOrNull?.innerText),
+      author: element.findElements('author').firstOrNull?.innerText,
+      comments: element.findElements('comments').firstOrNull?.innerText,
       source: element
           .findElements('source')
           .map((e) => RssSource.parse(e))

--- a/lib/domain/rss_source.dart
+++ b/lib/domain/rss_source.dart
@@ -8,7 +8,7 @@ class RssSource {
 
   factory RssSource.parse(XmlElement element) {
     var url = element.getAttribute('url');
-    var value = element.value;
+    var value = element.innerText;
 
     return RssSource(url, value);
   }

--- a/lib/domain/syndication/syndication.dart
+++ b/lib/domain/syndication/syndication.dart
@@ -17,7 +17,7 @@ class Syndication {
 
   factory Syndication.parse(XmlElement element) {
     SyndicationUpdatePeriod updatePeriod;
-    switch (element.findElements('sy:updatePeriod').firstOrNull?.value) {
+    switch (element.findElements('sy:updatePeriod').firstOrNull?.innerText) {
       case 'hourly':
         updatePeriod = SyndicationUpdatePeriod.hourly;
         break;
@@ -40,9 +40,10 @@ class Syndication {
     return Syndication(
       updatePeriod: updatePeriod,
       updateFrequency: int.tryParse(
-          element.findElements('sy:updateFrequency').firstOrNull?.value ?? '1'),
+          element.findElements('sy:updateFrequency').firstOrNull?.innerText ??
+              '1'),
       updateBase: parseDateTime(
-          element.findElements('sy:updateBase').firstOrNull?.value),
+          element.findElements('sy:updateBase').firstOrNull?.innerText),
     );
   }
 }

--- a/lib/util/datetime.dart
+++ b/lib/util/datetime.dart
@@ -1,10 +1,6 @@
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 import 'timezone.dart';
-
-/// The `Z` part is not yet implemented according to https://pub.dev/documentation/intl/latest/intl/DateFormat-class.html
-/// We will remove it for now and parse the timezone separately.
-const rfc822DatePattern = 'EEE, dd MMM yyyy HH:mm:ss';
-final rfc822DateFormat = DateFormat(rfc822DatePattern, 'en_US');
 
 DateTime? parseDateTime(dateString) {
   if (dateString == null) return null;
@@ -15,15 +11,28 @@ DateTime? parseDateTime(dateString) {
 /// We will parse the date string as UTC and then
 /// subtract the actual time offset from the parsed string.
 DateTime? _parseRfc822DateTime(String dateString) {
-  try {
-    final localTime = rfc822DateFormat.parse(dateString, true);
-    final timezone = dateString.trim().split(' ').last;
+  initializeDateFormatting('zh_CN', null);
 
-    final timeOffset = Duration(minutes: getTimeZoneOffset(timezone) ?? 0);
-    return localTime.subtract(timeOffset).toUtc();
-  } on FormatException {
-    return null;
+  /// The `Z` part is not yet implemented according to https://pub.dev/documentation/intl/latest/intl/DateFormat-class.html
+  /// We will remove it for now and parse the timezone separately.
+  const rfc822DatePattern = 'EEE, dd MMM yyyy HH:mm:ss';
+  final rfc822DateFormats = [
+    DateFormat(rfc822DatePattern, 'en_US'),
+    DateFormat(rfc822DatePattern, 'zh_CN'),
+  ];
+
+  for (var rfc822DateFormat in rfc822DateFormats) {
+    try {
+      final localTime = rfc822DateFormat.parse(dateString, true);
+      final timezone = dateString.trim().split(' ').last;
+
+      final timeOffset = Duration(minutes: getTimeZoneOffset(timezone) ?? 0);
+      return localTime.subtract(timeOffset).toUtc();
+    } on FormatException {
+      continue;
+    }
   }
+  return null;
 }
 
 DateTime? _parseIso8601DateTime(dateString) {

--- a/lib/util/xml.dart
+++ b/lib/util/xml.dart
@@ -22,7 +22,7 @@ Iterable<XmlElement>? findElements(
 
 bool parseBoolLiteral(XmlElement element, String tagName) {
   var v =
-      element.findElements(tagName).firstOrNull?.value?.toLowerCase().trim();
+      element.findElements(tagName).firstOrNull?.innerText.toLowerCase().trim();
   if (v == null) return false;
   return ['yes', 'true'].contains(v);
 }


### PR DESCRIPTION
If you use `value` (excluding the content of child nodes), you will get a lot of nulls.

---

The modified lines are consistent with [this commit](https://github.com/OmkarDabade/webfeed_plus/commit/0b3ed45e361187ccb55a8d30bceeecc6a4519732).

### updated 2024.07.03

https://github.com/OmkarDabade/webfeed_plus/pull/2/commits/6bb4dbd776e9dec3ea876ba1dffd20f9c67805f5

datetime format now support zh_CN.